### PR TITLE
chore: fix a compilation bug on MacOS and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ kernelmemfs
 mkfs
 .gdbinit
 .gdb_history
+.depend

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ mkfs
 .gdbinit
 .gdb_history
 .depend
+.history/
+.vscode/
+cscope.out

--- a/sh.c
+++ b/sh.c
@@ -53,6 +53,8 @@ int fork1(void);  // Fork but panics on failure.
 void panic(char*);
 struct cmd *parsecmd(char*);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winfinite-recursion"
 // Execute cmd.  Never returns.
 void
 runcmd(struct cmd *cmd)
@@ -129,6 +131,7 @@ runcmd(struct cmd *cmd)
   }
   exit();
 }
+#pragma GCC diagnostic pop
 
 int
 getcmd(char *buf, int nbuf)

--- a/usertests.c
+++ b/usertests.c
@@ -282,7 +282,7 @@ exectest(void)
 }
 
 void
-nullptr(void)
+nullptrtest(void)
 {
   printf(1, "null pointer test\n");
   printf(1, "expect one killed process\n");
@@ -1648,7 +1648,7 @@ main(int argc, char *argv[])
   pipe1();
   preempt();
   exitwait();
-  nullptr();
+  nullptrtest();
 
   rmdot();
   fourteen();


### PR DESCRIPTION
1. Got the following compilation error on MacOS 15.5 (x86_64-elf-gcc (GCC) 15.1.0). It seems because `nullptr` becomes a keyword in C++11 and later.
```
make
rm -f ".depend"
x86_64-elf-gcc -MM bio.c bootmain.c cat.c console.c echo.c exec.c file.c forktest.c fs.c grep.c ide.c init.c ioapic.c kalloc.c kbd.c kill.c lapic.c ln.c log.c ls.c main.c memide.c mkdir.c mkfs.c mp.c pipe.c printf.c proc.c rm.c sh.c sleeplock.c spinlock.c stressfs.c string.c syscall.c sysfile.c sysproc.c trap.c uart.c ulib.c umalloc.c usertests.c vm.c wc.c zombie.c > ".depend"
x86_64-elf-gcc -fno-pic -static -fno-builtin -fno-strict-aliasing -Wall -MD -ggdb -fno-omit-frame-pointer -ffreestanding -fno-common -nostdlib -m64 -DX64 -mcmodel=large -mtls-direct-seg-refs -mno-red-zone -O0 -fno-stack-protector   -c -o usertests.o usertests.c
usertests.c:285:1: error: expected identifier or '(' before 'nullptr'
  285 | nullptr(void)
      | ^~~~~~~
usertests.c: In function 'main':
usertests.c:1651:3: error: called object is not a function or function pointer
 1651 |   nullptr();
      |   ^~~~~~~
make: *** [usertests.o] Error 1
```

2. It seems that `.depend` should be added to `.gitignore`.